### PR TITLE
Fix biochar parameter names and remove EW capital cost

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1006,7 +1006,6 @@ def add_EW(n, costs):
        bus1="co2 atmosphere",
        bus2= nodes + " EW co2 store",
        carrier = "EW",
-       capital_cost = costs.at["Enhanced Weathering", "investment"]/costs.at["Enhanced Weathering", "electricity-input"],
        marginal_cost = costs.at["Enhanced Weathering", "VOM"]/costs.at["Enhanced Weathering", "electricity-input"],
        efficiency=-1/costs.at["Enhanced Weathering", "electricity-input"],
        efficiency2=1/costs.at["Enhanced Weathering", "electricity-input"],

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -879,9 +879,9 @@ def add_biochar(n, costs):
           capital_cost = costs.at["biochar pyrolysis", "fixed"],
           marginal_cost = costs.at["biochar pyrolysis", "VOM"],
           efficiency = 1,
-          efficiency2 = -costs.at["biochar pyrolysis", "biomass input"],
-          efficiency3 = -costs.at["biochar pyrolysis", "electricity input"],
-          efficiency4 = costs.at["biochar pyrolysis", "heat output"],
+          efficiency2 = -costs.at["biochar pyrolysis", "biomass-input"],
+          efficiency3 = -costs.at["biochar pyrolysis", "electricity-input"],
+          efficiency4 = costs.at["biochar pyrolysis", "heat-output"],
           p_nom_extendable = True
          )
 


### PR DESCRIPTION
## Summary

- Renamed biochar pyrolysis parameters in `add_biochar()` to use hyphens instead of spaces, aligning with technology data standard (`biomass input` → `biomass-input`, `electricity input` → `electricity-input`, `heat output` → `heat-output`)
- Removed `capital_cost` from the Enhanced Weathering link in `add_EW()` (was incorrectly set there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)